### PR TITLE
inventory: Set item weight to zero if the bundle size is zero

### DIFF
--- a/5eOGL-DND-Beyond-Importer/BeyondImporter.js
+++ b/5eOGL-DND-Beyond-Importer/BeyondImporter.js
@@ -237,7 +237,7 @@
                         attributes["repeating_inventory_"+row+"_itemname"] = item.definition.name;
                         attributes["repeating_inventory_"+row+"_equipped"] = (item.equipped) ? '1' : '0';
                         attributes["repeating_inventory_"+row+"_itemcount"] = item.quantity;
-                        attributes["repeating_inventory_"+row+"_itemweight"] = item.definition.weight / item.definition.bundleSize;
+                        attributes["repeating_inventory_"+row+"_itemweight"] = (item.definition.bundleSize != 0 ? item.definition.weight / item.definition.bundleSize : item.definition.weight);
                         attributes["repeating_inventory_"+row+"_itemcontent"] = replaceChars(item.definition.description);
                         var _itemmodifiers = 'Item Type: ' + item.definition.type;
                         if(typeof item.definition.damage === 'object' && item.definition.type !== 'Ammunition'){


### PR DESCRIPTION
Some items, such as Tej, may have a bundle size of zero. When this is
the case, dividing by zero makes the item weight NaN and causes the
import to fail.

Check for zero bundle sizes and default the weight to the overall item
weight.

This can be tested by adding [Tej](https://www.dndbeyond.com/equipment/tej) to a character's inventory and attempting an import.