### PR TITLE
several fixes

### DIFF
--- a/5eOGL-DND-Beyond-Importer/BeyondImporter.js
+++ b/5eOGL-DND-Beyond-Importer/BeyondImporter.js
@@ -34,7 +34,7 @@
     let object;
 
     // Styling for the chat responses.
-    const style = "margin-left: -45px; overflow: hidden; background-color: #fff; border: 1px solid #000; padding: 5px; border-radius: 5px;";
+    const style = "margin-left: 0px; overflow: hidden; background-color: #fff; border: 1px solid #000; padding: 5px; border-radius: 5px;";
     const buttonStyle = "background-color: #000; border: 1px solid #292929; border-radius: 3px; padding: 5px; color: #fff; text-align: center; float: right;"
 
     let jack = '0';

--- a/5eOGL-DND-Beyond-Importer/BeyondImporter.js
+++ b/5eOGL-DND-Beyond-Importer/BeyondImporter.js
@@ -907,7 +907,7 @@
                 if(!initadv && initdis) init_style = '{@{d20},@{d20}}kl1';
 
                 // Saving Throw Bonuses
-                let stBonuses = getObjects(character.modifiers, 'subType', 'saving-throws');
+                let stBonuses = getObjects(character.modifiers, 'subType', 'saving-throws', ['item']);
                 let stBonTotals = [0,0,0,0,0,0,0];
                 stBonuses.forEach((bonus) => {
                     if(bonus.statId != null) {
@@ -919,7 +919,7 @@
                 });
                 for(let i in _ABILITIES) {
                     let abl = _ABILITY[_ABILITIES[i]];
-                    let stBonuses = getObjects(character.modifiers, 'subType', abl+'-saving-throws');
+                    let stBonuses = getObjects(character.modifiers, 'subType', abl+'-saving-throws', ['item']);
                     let stBonTotals = [0,0,0,0,0,0,0];
                     stBonuses.forEach((bonus) => {
                         if(bonus.statId != null) {
@@ -1478,12 +1478,16 @@
         return total;
     };
 
-    //return an array of objects according to key, value, or key and value matching
-    const getObjects = (obj, key, val) => {
+    //return an array of objects according to key, value, or key and value matching, optionally ignoring objects in array of names
+    const getObjects = (obj, key, val, except) => {
+        except = except || [];
         let objects = [];
         for (let i in obj) {
             if (!obj.hasOwnProperty(i)) continue;
             if (typeof obj[i] == 'object') {
+                if (except.indexOf(i) != -1) {
+                    continue;
+                }
                 objects = objects.concat(getObjects(obj[i], key, val));
             } else
             //if key matches and value matches or if key matches and value is not passed (eliminating the case where key matches but passed value does not)

--- a/5eOGL-DND-Beyond-Importer/BeyondImporter.js
+++ b/5eOGL-DND-Beyond-Importer/BeyondImporter.js
@@ -956,14 +956,14 @@
                     'alignment': character.alignmentId == null ? '' : alignments[character.alignmentId],
 
                     // Bio Info
-                    // 'age': character.age ? character.age : '',
-                    // 'size': character.size,
-                    // 'height': character.height ? character.height : '',
-                    // 'weight': character.weight ? character.weight : '',
-                    // 'eyes': character.eyes ? character.eyes : '',
-                    // 'hair': character.hair ? character.hair : '',
-                    // 'skin': character.skin ? character.skin : '',
-                    // 'character_appearance': character.traits.appearance,
+                    'age': (character.age || ''),
+                    'size': (character.size || ''),
+                    'height': (character.height || ''),
+                    'weight': (character.weight || ''),
+                    'eyes': (character.eyes || ''),
+                    'hair': (character.hair || ''),
+                    'skin': (character.skin || ''),
+                    'character_appearance': (character.traits.appearance || ''),
 
                     // Class(es)
                     'class': character.classes[0].definition.name,

--- a/5eOGL-DND-Beyond-Importer/BeyondImporter.js
+++ b/5eOGL-DND-Beyond-Importer/BeyondImporter.js
@@ -799,17 +799,6 @@
                     }
                 });
 
-                attributes = {};
-                abilities.forEach((ability) => {
-                    let abl = _ABILITY[ability];
-                    let saves = getObjects(character, 'subType', abl+'-saving-throws');
-                    saves.forEach((save) => {
-                        if(save.type == 'proficiency') {
-                            attributes[abl + '_save_prof'] = "(@{pb})";
-                        }
-                    });
-                });
-                Object.assign(all_attributes, attributes);
 
                 let hpModifiers = getObjects(character.modifiers.class, 'type', 'half-proficiency');
                 let hprModifiers = getObjects(character.modifiers.class, 'type', 'half-proficiency-round-up');
@@ -906,7 +895,8 @@
                 if(initadv && !initdis) init_style = '{@{d20},@{d20}}kh1';
                 if(!initadv && initdis) init_style = '{@{d20},@{d20}}kl1';
 
-                // Saving Throw Bonuses
+                // Saving Throw Bonuses and proficiencies
+                let save_proficiency_attributes = {}
                 let stBonuses = getObjects(character.modifiers, 'subType', 'saving-throws', ['item']);
                 let stBonTotals = [0,0,0,0,0,0,0];
                 stBonuses.forEach((bonus) => {
@@ -927,6 +917,9 @@
                         }
                         if(bonus.value != null) {
                             stBonTotals[parseInt(i)] += bonus.value;
+                        }
+                        if(bonus.type == 'proficiency') {
+                            save_proficiency_attributes[abl + '_save_prof'] = "(@{pb})";
                         }
                     });
                 }
@@ -1029,6 +1022,7 @@
 
                 Object.assign(all_attributes, other_attributes);
                 // Object.assign(all_attributes, bonus_attributes);
+                Object.assign(all_attributes, save_proficiency_attributes);
 
                 setAttrs(object.id, all_attributes);
 

--- a/5eOGL-DND-Beyond-Importer/BeyondImporter.js
+++ b/5eOGL-DND-Beyond-Importer/BeyondImporter.js
@@ -1052,10 +1052,10 @@
                     hpAttr.set('max', hp);
                 }
 
-                if(class_spells.length > 15 && state[state_name][beyond_caller.id].config.imports.class_spells) {
-                    sendChat(script_name, '<div style="'+style+'">Import of <b>' + character.name + '</b> is almost ready.<br><p>There are some more spells than expected, they will be imported over time.</p></div>', null, {noarchive:true});
+                if(class_spells.length > 0 && state[state_name][beyond_caller.id].config.imports.class_spells) {
+                    sendChat(script_name, '<div style="'+style+'">Import of <b>' + character.name + '</b> is almost ready.<br><p>Class spells are being imported over time.</p></div>', null, {noarchive:true});
                 } else {
-                    sendChat(script_name, '<div style="'+style+'">Import of <b>' + character.name + '</b> is ready.</div>', null, {noarchive:true});
+                    reportReady(character)
                 }
             }
         }
@@ -1082,6 +1082,13 @@
         return 0;
     };
 
+    const reportReady = (character) => {
+        // TODO this is nonsense.  we aren't actually done importing, because notifications in the character sheet are firing for quite a while
+        // after we finish changing things (especially on first import) and we have no way (?) to wait for it to be done.   These are not sheet workers
+        // on which we can wait.
+        sendChat(script_name, '<div style="'+style+'">Import of <b>' + character.name + '</b> is ready at https://journal.roll20.net/character/' + object.id +'</div>', null, {noarchive:true});
+    }
+    
     const getFeatureSpells = (character, traitId, featureType) => {
         let spellsArr = [];
         if(character.spells[featureType] == null) return spellsArr;
@@ -1113,6 +1120,9 @@
             if (index < array.length) {
                 // set Timeout for async iteration
                 onSheetWorkerCompleted(doChunk);
+            } else {
+                // truly done now
+                reportReady(character);
             }
         }
         doChunk();

--- a/5eOGL-DND-Beyond-Importer/BeyondImporter.js
+++ b/5eOGL-DND-Beyond-Importer/BeyondImporter.js
@@ -143,7 +143,7 @@
                 if(!object) {
                     // Create character object
                     object = createObj("character", {
-                        name: character.name + state[state_name][beyond_caller.id].config.prefix,
+                        name: state[state_name][beyond_caller.id].config.prefix + character.name + state[state_name][beyond_caller.id].config.suffix,
                         inplayerjournals: playerIsGM(msg.playerid) ? state[state_name][beyond_caller.id].config.inplayerjournals : msg.playerid,
                         controlledby: playerIsGM(msg.playerid) ? state[state_name][beyond_caller.id].config.controlledby : msg.playerid
                     });


### PR DESCRIPTION
The biggest change is not to import saving throw bonuses from items when calculating the global saving throw bonuses.  They will be gained when item is imported, leading to double counting.  For example, Cloak of Protection will give +1 to saves when the item is imported, but it also increments the global save modifier by 1, because it is found under character.modifiers.item  

This change excepts the character.modifers.item from scanning for save bonuses

All other changes are minor